### PR TITLE
Add progress screen with topic stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ A mobile algebra learning app built with React Native and Expo. This changelog t
 - **Enhanced offline capability**: Problems now truly bundled with app, no hardcoded data
 
 #### ✅ **Home Tab Implementation**
-- **Added third tab**: Now has complete Home → Practice → Settings navigation
+- **Added fourth tab**: Home, Practice, Progress, Settings navigation
 - **Welcome screen design**: Clean landing page with app branding and quick actions
 - **Progress dashboard**: Shows solved/attempted problems and accuracy when available
 - **Daily tips rotation**: Helpful learning tips that change each day deterministically
 - **Navigation integration**: Quick access buttons to Practice and Settings tabs
 
 #### 🔧 **Week 2 Goals - 100% Complete**
-- ✅ **Navigation tabs**: Home, Practice, Settings
+- ✅ **Navigation tabs**: Home, Practice, Progress, Settings
 - ✅ **Bundled JSON problems**: Offline sample data system
 - ✅ **SQLite integration**: Full persistence with progress tracking
 - ✅ **Practice loop**: Question → answer → feedback cycle
@@ -89,7 +89,8 @@ UserProgress (id, currentBatchId, problemsAttempted, problemsCorrect, lastSyncTi
 app/(tabs)/          # Tab navigation screens
 ├── home.tsx         # Welcome screen with progress dashboard
 ├── index.tsx        # Practice screen (main problem solving)
-├── settings.tsx     # Settings and statistics
+├── progress.tsx     # Progress dashboard with statistics
+├── settings.tsx     # App settings
 └── _layout.tsx      # Tab layout configuration
 
 components/          # Reusable UI components
@@ -118,7 +119,7 @@ assets/data/        # Bundled data
 ## 🎯 Current Status
 
 ### **Functional Features**
-- ✅ Three-tab navigation (Home, Practice, Settings)
+- ✅ Four-tab navigation (Home, Practice, Progress, Settings)
 - ✅ Algebra problem solving with answer validation
 - ✅ Step-by-step solutions for incorrect answers
 - ✅ Progress tracking with accuracy statistics

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -37,6 +37,15 @@ export default function TabLayout() {
             ),
         }}
     />
+      <Tabs.Screen
+        name="progress"
+        options={{
+            title: 'Progress',
+            tabBarIcon: ({color, focused}) => (
+                <Ionicons name={focused ? 'stats-chart' : 'stats-chart-outline'} color={color} size={24} />
+            ),
+        }}
+    />
         <Tabs.Screen
         name="settings"
         options={{

--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -1,0 +1,122 @@
+import { db } from '@/services/database';
+import { TopicAccuracy } from '@/services/database';
+import { useProblemStore } from '@/store/problemStore';
+import React, { useEffect, useState } from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+
+export default function ProgressScreen() {
+  const { userProgress } = useProblemStore();
+  const [topicStats, setTopicStats] = useState<TopicAccuracy[]>([]);
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      const stats = await db.getTopicAccuracyStats();
+      setTopicStats(stats);
+    };
+    fetchStats();
+  }, [userProgress]);
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.contentContainer}>
+      <Text style={styles.title}>Progress</Text>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Overall Stats</Text>
+        {userProgress ? (
+          <View style={styles.statsContainer}>
+            <View style={styles.statItem}>
+              <Text style={styles.statLabel}>Problems Attempted:</Text>
+              <Text style={styles.statValue}>{userProgress.problemsAttempted}</Text>
+            </View>
+            <View style={styles.statItem}>
+              <Text style={styles.statLabel}>Problems Correct:</Text>
+              <Text style={styles.statValue}>{userProgress.problemsCorrect}</Text>
+            </View>
+            <View style={styles.statItem}>
+              <Text style={styles.statLabel}>Accuracy:</Text>
+              <Text style={styles.statValue}>
+                {userProgress.problemsAttempted > 0
+                  ? `${Math.round((userProgress.problemsCorrect / userProgress.problemsAttempted) * 100)}%`
+                  : '0%'}
+              </Text>
+            </View>
+          </View>
+        ) : (
+          <Text style={styles.noDataText}>No progress data available</Text>
+        )}
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Accuracy by Topic</Text>
+        {topicStats.length === 0 ? (
+          <Text style={styles.noDataText}>No attempts yet</Text>
+        ) : (
+          <View style={styles.statsContainer}>
+            {topicStats.map((stat) => (
+              <View key={stat.problemType} style={styles.statItem}>
+                <Text style={styles.statLabel}>{stat.problemType}</Text>
+                <Text style={styles.statValue}>{stat.correct}/{stat.attempted} correct</Text>
+              </View>
+            ))}
+          </View>
+        )}
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#25292e',
+  },
+  contentContainer: {
+    padding: 20,
+    paddingTop: 40,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    color: '#fff',
+    textAlign: 'center',
+    marginBottom: 30,
+  },
+  section: {
+    marginBottom: 30,
+    backgroundColor: '#333',
+    borderRadius: 12,
+    padding: 20,
+  },
+  sectionTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: '#ffd33d',
+    marginBottom: 15,
+  },
+  statsContainer: {
+    gap: 12,
+  },
+  statItem: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: '#444',
+  },
+  statLabel: {
+    fontSize: 16,
+    color: '#fff',
+  },
+  statValue: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: '#ffd33d',
+  },
+  noDataText: {
+    fontSize: 16,
+    color: '#999',
+    textAlign: 'center',
+    fontStyle: 'italic',
+  },
+});

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -5,7 +5,7 @@ import React, { useState } from 'react';
 import { Alert, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 export default function SettingsScreen() {
-  const { userProgress, resetProgress } = useProblemStore();
+  const { resetProgress } = useProblemStore();
   const [isResetting, setIsResetting] = useState(false);
 
   // Get current database type
@@ -44,32 +44,6 @@ export default function SettingsScreen() {
     <ScrollView style={styles.container} contentContainerStyle={styles.contentContainer}>
       <Text style={styles.title}>Settings</Text>
 
-      {/* Progress Stats Section */}
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Progress Stats</Text>
-        {userProgress ? (
-          <View style={styles.statsContainer}>
-            <View style={styles.statItem}>
-              <Text style={styles.statLabel}>Problems Attempted:</Text>
-              <Text style={styles.statValue}>{userProgress.problemsAttempted}</Text>
-            </View>
-            <View style={styles.statItem}>
-              <Text style={styles.statLabel}>Problems Correct:</Text>
-              <Text style={styles.statValue}>{userProgress.problemsCorrect}</Text>
-            </View>
-            <View style={styles.statItem}>
-              <Text style={styles.statLabel}>Accuracy:</Text>
-              <Text style={styles.statValue}>
-                {userProgress.problemsAttempted > 0
-                  ? `${Math.round((userProgress.problemsCorrect / userProgress.problemsAttempted) * 100)}%`
-                  : '0%'}
-              </Text>
-            </View>
-          </View>
-        ) : (
-          <Text style={styles.noDataText}>No progress data available</Text>
-        )}
-      </View>
 
       {/* Database Status Section */}
       <View style={styles.section}>
@@ -140,32 +114,6 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     color: '#ffd33d',
     marginBottom: 15,
-  },
-  statsContainer: {
-    gap: 12,
-  },
-  statItem: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingVertical: 8,
-    borderBottomWidth: 1,
-    borderBottomColor: '#444',
-  },
-  statLabel: {
-    fontSize: 16,
-    color: '#fff',
-  },
-  statValue: {
-    fontSize: 16,
-    fontWeight: 'bold',
-    color: '#ffd33d',
-  },
-  noDataText: {
-    fontSize: 16,
-    color: '#999',
-    textAlign: 'center',
-    fontStyle: 'italic',
   },
   databaseStatusContainer: {
     flexDirection: 'row',

--- a/services/database/index.ts
+++ b/services/database/index.ts
@@ -156,5 +156,10 @@ export const db = USE_MOCK_DB ? mockDb : {
         problemsCorrect: progress.problemsCorrect + (isCorrect ? 1 : 0)
       });
     }
+  },
+
+  // Get accuracy stats by topic
+  async getTopicAccuracyStats() {
+    return await problemService.getTopicAccuracyStats();
   }
 };

--- a/services/database/mockDb.ts
+++ b/services/database/mockDb.ts
@@ -175,6 +175,30 @@ export const mockDb = {
     }
   },
 
+  async getTopicAccuracyStats() {
+    await initializeMockData();
+    const stats: Record<string, { attempted: number; correct: number }> = {};
+    problems.forEach((p) => {
+      if (!p.isCompleted) return;
+      const type = p.problemType;
+      if (!stats[type]) {
+        stats[type] = { attempted: 0, correct: 0 };
+      }
+      stats[type].attempted += 1;
+      const userAns = String(p.userAnswer ?? '').trim();
+      const correctAns = String(p.answer ?? '').trim();
+      if (userAns && userAns === correctAns) {
+        stats[type].correct += 1;
+      }
+    });
+    return Object.entries(stats).map(([problemType, data]) => ({
+      problemType,
+      attempted: data.attempted,
+      correct: data.correct,
+      incorrect: data.attempted - data.correct,
+    }));
+  },
+
   // Add batch function for completeness
   async addBatch(batch: Omit<ProblemBatch, 'id' | 'importedAt'>, problemsData: Omit<Problem, 'id' | 'batchId' | 'isCompleted' | 'userAnswer' | 'createdAt' | 'updatedAt'>[]) {
     await initializeMockData();

--- a/services/database/schema.ts
+++ b/services/database/schema.ts
@@ -36,6 +36,14 @@ export interface UserProgress {
   updatedAt: string;
 }
 
+// Statistics for accuracy broken down by problem type
+export interface TopicAccuracy {
+  problemType: string;
+  attempted: number;
+  correct: number;
+  incorrect: number;
+}
+
 export const CREATE_PROBLEM_BATCHES_TABLE = `
 CREATE TABLE IF NOT EXISTS ProblemBatches (
   id TEXT PRIMARY KEY NOT NULL,


### PR DESCRIPTION
## Summary
- introduce dedicated Progress tab
- move settings sections and stats to new progress screen
- compute topic accuracy stats in database services
- update tab layout and README

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f573aec208328b5393582ab3939af