### PR TITLE
Add KaTeX math renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ UserProgress (id, currentBatchId, problemsAttempted, problemsCorrect, lastSyncTi
 - **Navigation**: Expo Router with file-based routing
 - **Language**: TypeScript with strict type checking
 - **Build**: EAS Build with multiple variants
+- **Math Rendering**: react-native-katex for LaTeX equations
 
 ### **Project Structure**
 ```
@@ -162,6 +163,7 @@ The daily problem generation system has been enhanced to address several issues:
 6. **Better Error Handling**: Continue generation even if some problem types fail
 7. **Enhanced Validation**: Validate answer formats match expected types and detect calculator-requiring answers
 8. **Detailed Statistics**: Track success/failure rates and provide better debugging info
+9. **LaTeX Output**: Problems and solution steps are now generated in LaTeX for rendering with `react-native-katex`
 
 ### Answer Quality Standards
 

--- a/components/ProblemContainer.tsx
+++ b/components/ProblemContainer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+import Katex from 'react-native-katex';
 
 // Define the structure for a problem
 export interface Problem {
@@ -16,7 +17,11 @@ type Props = {
 const ProblemContainer = ({ problem }: Props) => {
   return (
     <View style={styles.container}>
-      <Text style={styles.problemText}>{problem.equation}</Text>
+      <Katex
+        expression={problem.equation}
+        style={styles.problemText}
+        displayMode
+      />
     </View>
   );
 };

--- a/components/StepByStepSolution.tsx
+++ b/components/StepByStepSolution.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
+import Katex from 'react-native-katex';
 import { useCollapsible } from 'react-native-fast-collapsible';
 import Animated from 'react-native-reanimated';
 
@@ -46,7 +47,14 @@ const StepByStepSolution: React.FC<StepByStepSolutionProps> = ({
 
 // Individual step component for better modularity
 const SolutionStep: React.FC<{ step: string }> = ({ step }) => {
-  return <Text style={styles.solutionStep}>{step}</Text>;
+  return (
+    <Katex
+      expression={step}
+      style={styles.solutionStep}
+      displayMode
+      colorIsTextColor
+    />
+  );
 };
 
 const styles = StyleSheet.create({

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "react-native": "0.79.2",
         "react-native-fast-collapsible": "^1.1.2",
         "react-native-gesture-handler": "~2.24.0",
+        "react-native-katex": "^1.3.0",
         "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
@@ -1762,9 +1763,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.3.tgz",
-      "integrity": "sha512-+F8CnfhuLhwUACIJMLWnjz6zvzYM2r0yeIHKlbgfw7ml8rOMJsXNXV/hyRcb3nb493gRs4WvYpQAndWj/qQmkQ==",
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.5.tgz",
+      "integrity": "sha512-JF6uE2s67f0y2RZcm2kpAUEbD50vH62TyWVebxwHAlbSdM49VqPz8t4a1uIjp4NIOIZ4xzLfjY5emt/RCyC7TQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -2192,9 +2193,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.27.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.27.4.tgz",
-      "integrity": "sha512-Glp/0n8xuj+E1588otw5rjJkTXfzW7FjH3IIUrfqiZOPQCd2vbg8e+DQE8jK9g4V5/zrxFW+D9WM9gboRPELpQ==",
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.27.5.tgz",
+      "integrity": "sha512-uhB8yHerfe3MWnuLAhEbeQ4afVoqv8BQsPqrTv7e/jZ9y00kJL6l9a/f4OWaKxotmjzewfEyXE1vgDJenkQ2/Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -2635,9 +2636,9 @@
       }
     },
     "node_modules/@expo/cli": {
-      "version": "0.24.13",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.24.13.tgz",
-      "integrity": "sha512-2LSdbvYs+WmUljnplQXMCUyNzyX4H+F4l8uExfA1hud25Bl5kyaGrx1jjtgNxMTXmfmMjvgBdK798R50imEhkA==",
+      "version": "0.24.14",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.24.14.tgz",
+      "integrity": "sha512-o+QYyfIBhSRTgaywKTLJhm2Fg5PrSeUVCXS+uQySamgoMjLNhHa8QwE64mW/FmJr5hZLiqUEQxb60FK4JcyqXg==",
       "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.8",
@@ -2657,7 +2658,7 @@
         "@expo/spawn-async": "^1.7.2",
         "@expo/ws-tunnel": "^1.0.1",
         "@expo/xcpretty": "^4.3.0",
-        "@react-native/dev-middleware": "0.79.2",
+        "@react-native/dev-middleware": "0.79.3",
         "@urql/core": "^5.0.6",
         "@urql/exchange-retry": "^1.3.0",
         "accepts": "^1.3.8",
@@ -2672,7 +2673,7 @@
         "debug": "^4.3.4",
         "env-editor": "^0.4.1",
         "freeport-async": "^2.0.0",
-        "getenv": "^1.0.0",
+        "getenv": "^2.0.0",
         "glob": "^10.4.2",
         "lan-network": "^0.1.6",
         "minimatch": "^9.0.0",
@@ -2706,6 +2707,55 @@
         "expo-internal": "build/bin/cli"
       }
     },
+    "node_modules/@expo/cli/node_modules/@react-native/debugger-frontend": {
+      "version": "0.79.3",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.79.3.tgz",
+      "integrity": "sha512-ImNDuEeKH6lEsLXms3ZsgIrNF94jymfuhPcVY5L0trzaYNo9ZFE9Ni2/18E1IbfXxdeIHrCSBJlWD6CTm7wu5A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@expo/cli/node_modules/@react-native/dev-middleware": {
+      "version": "0.79.3",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.79.3.tgz",
+      "integrity": "sha512-x88+RGOyG71+idQefnQg7wLhzjn/Scs+re1O5vqCkTVzRAc/f7SdHMlbmECUxJPd08FqMcOJr7/X3nsJBrNuuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/ttlcache": "^1.4.1",
+        "@react-native/debugger-frontend": "0.79.3",
+        "chrome-launcher": "^0.15.2",
+        "chromium-edge-launcher": "^0.2.0",
+        "connect": "^3.6.5",
+        "debug": "^2.2.0",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "open": "^7.0.3",
+        "serve-static": "^1.16.2",
+        "ws": "^6.2.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@expo/cli/node_modules/@react-native/dev-middleware/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@expo/cli/node_modules/@react-native/dev-middleware/node_modules/ws": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
+      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+      "license": "MIT",
+      "dependencies": {
+        "async-limiter": "~1.0.0"
+      }
+    },
     "node_modules/@expo/cli/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -2713,6 +2763,15 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@expo/cli/node_modules/getenv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
+      "integrity": "sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@expo/cli/node_modules/minimatch": {
@@ -2729,6 +2788,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/@expo/cli/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/@expo/cli/node_modules/semver": {
       "version": "7.7.2",
@@ -3863,22 +3928,62 @@
       }
     },
     "node_modules/@react-native/babel-plugin-codegen": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.79.2.tgz",
-      "integrity": "sha512-d+NB7Uosn2ZWd4O4+7ZkB6q1a+0z2opD/4+Bzhk/Tv6fc5FrSftK2Noqxvo3/bhbdGFVPxf0yvLE8et4W17x/Q==",
+      "version": "0.79.3",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.79.3.tgz",
+      "integrity": "sha512-Zb8F4bSEKKZfms5n1MQ0o5mudDcpAINkKiFuFTU0PErYGjY3kZ+JeIP+gS6KCXsckxCfMEKQwqKicP/4DWgsZQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.25.3",
-        "@react-native/codegen": "0.79.2"
+        "@react-native/codegen": "0.79.3"
       },
       "engines": {
         "node": ">=18"
       }
     },
+    "node_modules/@react-native/babel-plugin-codegen/node_modules/@react-native/codegen": {
+      "version": "0.79.3",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.79.3.tgz",
+      "integrity": "sha512-CZejXqKch/a5/s/MO5T8mkAgvzCXgsTkQtpCF15kWR9HN8T+16k0CsN7TXAxXycltoxiE3XRglOrZNEa/TiZUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.1.1",
+        "hermes-parser": "0.25.1",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "yargs": "^17.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
+      }
+    },
+    "node_modules/@react-native/babel-plugin-codegen/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@react-native/babel-preset": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.79.2.tgz",
-      "integrity": "sha512-/HNu869oUq4FUXizpiNWrIhucsYZqu0/0spudJEzk9SEKar0EjVDP7zkg/sKK+KccNypDQGW7nFXT8onzvQ3og==",
+      "version": "0.79.3",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.79.3.tgz",
+      "integrity": "sha512-VHGNP02bDD2Ul1my0pLVwe/0dsEBHxR343ySpgnkCNEEm9C1ANQIL2wvnJrHZPcqfAkWfFQ8Ln3t+6fdm4A/Dg==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -3922,7 +4027,7 @@
         "@babel/plugin-transform-typescript": "^7.25.2",
         "@babel/plugin-transform-unicode-regex": "^7.24.7",
         "@babel/template": "^7.25.0",
-        "@react-native/babel-plugin-codegen": "0.79.2",
+        "@react-native/babel-plugin-codegen": "0.79.3",
         "babel-plugin-syntax-hermes-parser": "0.25.1",
         "babel-plugin-transform-flow-enums": "^0.0.2",
         "react-refresh": "^0.14.0"
@@ -6543,9 +6648,9 @@
       }
     },
     "node_modules/babel-preset-expo": {
-      "version": "13.1.11",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-13.1.11.tgz",
-      "integrity": "sha512-jigWjvhRVdm9UTPJ1wjLYJ0OJvD5vLZ8YYkEknEl6+9S1JWORO/y3xtHr/hNj5n34nOilZqdXrmNFcqKc8YTsg==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-13.2.0.tgz",
+      "integrity": "sha512-oNUeUZPMNRPmx/2jaKJLSQFP/MFI1M91vP+Gp+j8/FPl9p/ps603DNwCaRdcT/Vj3FfREdlIwRio1qDCjY0oAA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.25.9",
@@ -6562,7 +6667,7 @@
         "@babel/plugin-transform-runtime": "^7.24.7",
         "@babel/preset-react": "^7.22.15",
         "@babel/preset-typescript": "^7.23.0",
-        "@react-native/babel-preset": "0.79.2",
+        "@react-native/babel-preset": "0.79.3",
         "babel-plugin-react-native-web": "~0.19.13",
         "babel-plugin-syntax-hermes-parser": "^0.25.1",
         "babel-plugin-transform-flow-enums": "^0.0.2",
@@ -8352,26 +8457,26 @@
       }
     },
     "node_modules/expo": {
-      "version": "53.0.9",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-53.0.9.tgz",
-      "integrity": "sha512-UFG68aVOpccg3s++S3pbtI3YCQCnlu/TFvhnQ5vaD3vhOox1Uk/f2O2T95jmwA/EvKvetqGj34lys3DNXvPqgQ==",
+      "version": "53.0.10",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-53.0.10.tgz",
+      "integrity": "sha512-rN3HcQOeum4i+4Fq1+wBuTWbUjHZqTE7YgGGioOtY2WnhYt+4OSrTlxjRjp13AtkLuKSKkh34gkdFMlUepKlXA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "0.24.13",
+        "@expo/cli": "0.24.14",
         "@expo/config": "~11.0.10",
         "@expo/config-plugins": "~10.0.2",
         "@expo/fingerprint": "0.12.4",
         "@expo/metro-config": "0.20.14",
         "@expo/vector-icons": "^14.0.0",
-        "babel-preset-expo": "~13.1.11",
+        "babel-preset-expo": "~13.2.0",
         "expo-asset": "~11.1.5",
         "expo-constants": "~17.1.6",
         "expo-file-system": "~18.1.10",
         "expo-font": "~13.3.1",
         "expo-keep-awake": "~14.1.4",
         "expo-modules-autolinking": "2.1.10",
-        "expo-modules-core": "2.3.13",
+        "expo-modules-core": "2.4.0",
         "react-native-edge-to-edge": "1.6.0",
         "whatwg-url-without-unicode": "8.0.0-3"
       },
@@ -8624,9 +8729,9 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "2.3.13",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-2.3.13.tgz",
-      "integrity": "sha512-vmKHv7tEo2wUQoYDV6grhsLsQfD3DUnew5Up3yNnOE1gHGQE+zhV1SBYqaPMPB12OvpyD1mlfzGhu6r9PODnng==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-2.4.0.tgz",
+      "integrity": "sha512-Ko5eHBdvuMykjw9P9C9PF54/wBSsGOxaOjx92I5BwgKvEmUwN3UrXFV4CXzlLVbLfSYUQaLcB220xmPfgvT7Fg==",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
@@ -13420,6 +13525,19 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-katex": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-katex/-/react-native-katex-1.3.0.tgz",
+      "integrity": "sha512-lDswf/oIPIrKDG6W7SB4YUpu9+JeJWGFwkFEpLH/8JBptMBkAZyFmVG3Lu88ql36LrGLq8Jfg+nlJKHsEBunow==",
+      "license": "MIT",
+      "dependencies": {
+        "react-native-webview": "^13.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16",
         "react-native": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-native": "0.79.2",
     "react-native-fast-collapsible": "^1.1.2",
     "react-native-gesture-handler": "~2.24.0",
+    "react-native-katex": "^1.3.0",
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",

--- a/scripts/generateProblems.js
+++ b/scripts/generateProblems.js
@@ -287,6 +287,7 @@ ACCEPTABLE ANSWERS: 3, -2, 1/2, 2/3, 0, 7, -1/4, 5/3
 UNACCEPTABLE ANSWERS: 1.2839, 2.7182, 0.3333..., √2, 3.14159, 1.7320
 
 Generate problems following the exact JSON schema structure.
+All equations and solution steps must be written in LaTeX syntax so they can be rendered with KaTeX.
 
 Constraints:
 - ${difficulty} difficulty means: ${getDifficultyDescription(difficulty)}


### PR DESCRIPTION
## Summary
- add `react-native-katex` for LaTeX-based math rendering
- render equations with `<Katex>` component
- show solution steps using KaTeX
- note new library in README and mention LaTeX output requirement
- update problem generation script to request LaTeX

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841df98e844832890c2b971f02fa77f